### PR TITLE
Paginação no frontend

### DIFF
--- a/frontend/src/components/List/ItemList.js
+++ b/frontend/src/components/List/ItemList.js
@@ -8,14 +8,18 @@ const Item = props => {
   const filteredErrors = useSelector(({ error: { filteredErrors } }) => filteredErrors);
   const dispatch = useDispatch()
 
-  const setSelected = idx => {
-    filteredErrors[idx].selected = !filteredErrors[idx].selected;
+  const setSelected = key => {
+    filteredErrors.forEach(item => {
+      if (item._id === key) {
+        item.selected = !item.selected;
+      };
+    });
     let items = filteredErrors.filter(e => e);
     dispatch(Actions.updateFilteredErrors(items));
   };
 
   const handleChange = () => {
-    setSelected(props.idx);
+    setSelected(props.item._id);
   };
 
   const goToErrorPage = () => {

--- a/frontend/src/components/List/ItemsList.js
+++ b/frontend/src/components/List/ItemsList.js
@@ -1,16 +1,22 @@
 import React, { useState, useEffect } from "react";
 import Item from "./ItemList";
-import { Table, Form } from "react-bootstrap";
+import { Table, Form, Pagination } from "react-bootstrap";
 import { useDispatch } from "react-redux";
 import { Creators as Actions } from "../../store/ducks/error";
 import { useSelector } from "react-redux";
-import { isMobile } from "react-device-detect"
+import { isMobile } from "react-device-detect";
 
 const Items = props => {
-  const filteredErrors = useSelector(({ error: { filteredErrors } }) => filteredErrors);
+  const filteredErrors = useSelector(
+    ({ error: { filteredErrors } }) => filteredErrors
+  );
   const dispatch = useDispatch();
 
   const [selectAll, setSelectAll] = useState(false);
+  const [activePage, setActivePage] = useState(1);
+  const [pages, setPages] = useState([]);
+  const [activePageErros, setActivePageErros] = useState([]);
+  const pageSize = 5;
 
   useEffect(() => {
     filteredErrors.forEach(item => {
@@ -18,39 +24,67 @@ const Items = props => {
     });
     let items = filteredErrors.filter(e => e);
     dispatch(Actions.updateFilteredErrors(items));
-  }, [selectAll]);//eslint-disable-line
+  }, [selectAll]); //eslint-disable-line
   // Foi desabilitado o eslint pois não é necessário ficar escutando as alterações nos métodos "dispatch" e "filteredErrors"
 
+  const handlePageChange = (event, page) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setActivePage(page);
+  };
+
+  useEffect(() => {
+    var items = filteredErrors.length;
+    if (items <= pageSize) setActivePage(1);
+    var pages = [];
+    var quotient = Math.trunc(items / pageSize);
+    var remainder = items % pageSize;
+    var totalPages = quotient + (remainder > 0 ? 1 : 0);
+    for (let number = 1; number <= totalPages; number++) {
+      pages.push(
+        <Pagination.Item
+          onClick={e => handlePageChange(e, number)}
+          key={number}
+          active={number === activePage}
+        >
+          {number}
+        </Pagination.Item>
+      );
+    }
+    setPages(pages);
+    var initial = (activePage - 1) * pageSize;
+    var pageErrors = filteredErrors.slice(initial, initial + pageSize);
+    setActivePageErros(pageErrors);
+  }, [filteredErrors, activePage]);
+
   return (
-    <Table striped bordered hover>
-      <thead>
-        <tr>
-          <th>
-            <Form.Check
-              value={selectAll}
-              checked={selectAll}
-              onChange={e => setSelectAll(e.target.checked)}
-            />
-          </th>
-          <th>Level</th>
-          <th>Log</th>
-          <th>{isMobile ? "#" : "Eventos"}</th>
-        </tr>
-      </thead>
-      <tbody style={{ cursor: "pointer" }}>
-        {filteredErrors.map((item, idx) => {
-          return (
-            <Item
-              key={idx}
-              item={item}
-              idx={idx}
-              history={props.history}
-            />
-          );
-        })}
-      </tbody>
-    </Table>
+    <>
+      <Table striped bordered hover>
+        <thead>
+          <tr>
+            <th>
+              <Form.Check
+                value={selectAll}
+                checked={selectAll}
+                onChange={e => setSelectAll(e.target.checked)}
+              />
+            </th>
+            <th>Level</th>
+            <th>Log</th>
+            <th>{isMobile ? "#" : "Eventos"}</th>
+          </tr>
+        </thead>
+        <tbody style={{ cursor: "pointer" }}>
+          {activePageErros.map((item, idx) => {
+            return (
+              <Item key={idx} item={item} idx={idx} history={props.history} />
+            );
+          })}
+        </tbody>
+      </Table>
+      <Pagination>{pages}</Pagination>
+    </>
   );
-}
+};
 
 export default Items;


### PR DESCRIPTION
Aplicada a paginação apenas no frontend.
A melhor abordagem seria solicitar apenas os dados da página desejada, evitando carregar e trafegar dados não usados, mas seria necessário alterar tanto o nosso backend quanto a lógica de outros filtros, exemplo: Quando alterada a origem deveria ser requisitada a página um com os dados da origem selecionada. Não havia tempo para tal alteração.